### PR TITLE
Add ordering the RoutePoints with held_karp

### DIFF
--- a/src/apps/routes/models.py
+++ b/src/apps/routes/models.py
@@ -24,7 +24,7 @@ class RoutePoint(models.Model):
     address = models.ForeignKey(Address, on_delete=models.CASCADE)
     latitude = models.DecimalField(max_digits=9, decimal_places=6)
     longitude = models.DecimalField(max_digits=9, decimal_places=6)
-    sequence_number = models.PositiveIntegerField(default=0, blank=True)  # number in order
+    sequence_number = models.PositiveIntegerField(default=0, blank=True, null=True)  # number in order
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
     arrival_time = models.TimeField(null=True, blank=True)

--- a/src/apps/routes/urls.py
+++ b/src/apps/routes/urls.py
@@ -8,4 +8,6 @@ urlpatterns = [
     path('<int:route_id>/', views.route_detail, name='route_detail'),
     path('create/', views.route_create, name='route_create'),
     path('<int:route_id>/update/', views.route_update, name='route_update'),
+    path('distances', views.test_distances, name='test_distances')
+
 ]

--- a/src/apps/routes/utils/held_karp.py
+++ b/src/apps/routes/utils/held_karp.py
@@ -9,10 +9,13 @@ def generate_distances(n):
             distances[i][j] = distances[j][i] = random.randint(1,99)
     return distances
 
-def held_karp(dists):
-    print(dists)
-    n = len(dists)
 
+def held_karp(points_dict):
+    print(points_dict)
+
+    n = len(points_dict)
+    dists = list(points_dict.values())
+    keys = list(points_dict.keys())
     s = {}
 
     for k in range(1, n):
@@ -24,7 +27,6 @@ def held_karp(dists):
             bits = 0
             for bit in subset:
                 bits |= 1 << bit
-
 
             for k in subset:
                 prev = bits & ~(1 << k)
@@ -51,8 +53,8 @@ def held_karp(dists):
         bits = new_bits
 
     path.append(0)
-
-    return opt, list(reversed(path))
-
-
-print(held_karp(generate_distances(20)))
+    path = list(reversed(path))
+    print(opt, path)
+    # map indexes to the keys
+    order = [keys[i] for i in path]
+    return opt, order

--- a/src/apps/routes/utils/routing.py
+++ b/src/apps/routes/utils/routing.py
@@ -1,0 +1,35 @@
+from django.shortcuts import get_object_or_404
+from ..models import Route, RoutePoint, RouteSegment
+import requests
+import random
+
+
+def request_distance(latitude1, longitude1, latitude2, longitude2):
+    rn = random
+    return rn.randint(1, 10)
+
+
+def create_list(route_id):
+    route = get_object_or_404(Route, pk=route_id)
+    route_points = (RoutePoint.objects.filter(route=route).only("id", "sequence_number", "latitude", "longitude")
+                    .order_by('sequence_number'))
+
+    matrix_of_points = dict()
+
+    for i in range(len(route_points)):
+        list_of_distances = []
+        for j in range(len(route_points)):
+            if i == j:
+                list_of_distances.append(0)
+            elif route_points[j].id in matrix_of_points:
+                list_of_distances.append(matrix_of_points[route_points[j].id][i])
+            else:
+                distance = request_distance(route_points[i].latitude, route_points[i].longitude,
+                                            route_points[j].latitude, route_points[j].longitude)
+                list_of_distances.append(distance)
+        matrix_of_points[route_points[i].id] = list_of_distances
+    print(matrix_of_points)
+    return matrix_of_points
+
+
+


### PR DESCRIPTION
I created an integration between existing held_karp algorithm and points pulled from the database. It constis of mix of dictionaries and lists, but the final result is the whole distance and the order of the points in the list of RoutePoint.ids format. Next step is to save these values in the sequence_number and implement the OSRM distance length.