### PR TITLE
Changes and fixes for AWS deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -126,7 +126,6 @@ jobs:
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v2
       with:
-        terraform_version: 1.5.0
         terraform_wrapper: false
 
     - name: Terraform Init

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -99,14 +99,6 @@ jobs:
         echo "Waiting 60 seconds for migration to complete..."
         sleep 60
 
-    - name: Check migration logs
-      working-directory: ./infra
-      run: |
-        CLUSTER_NAME=$(terraform output -raw ecs_cluster_name)
-        
-        echo "Checking migration logs..."
-        aws logs tail /ecs/app --follow --since 2m --format short || true
-
   deploy:
     needs: [build, migrate]
     if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.migrate.result == 'success' || needs.migrate.result == 'skipped')

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,7 +13,11 @@ on:
         required: false
         type: boolean
         default: true
-
+      deploy_solution:
+        description: 'Deploy the whole app without migration'
+        required: false
+        type: boolean
+        default: true
 env:
   AWS_REGION: eu-central-1
   ECR_REPOSITORY: trash-tracker/app
@@ -101,7 +105,7 @@ jobs:
 
   deploy:
     needs: [build, migrate]
-    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.migrate.result == 'success' || needs.migrate.result == 'skipped')
+    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.migrate.result == 'success' || needs.migrate.result == 'skipped') && github.event.inputs.deploy_solution == 'true'
     runs-on: ubuntu-latest
     
     steps:

--- a/infra/alb.tf
+++ b/infra/alb.tf
@@ -50,7 +50,7 @@ module "alb" {
         healthy_threshold   = 2
         interval            = 30
         matcher             = "200"
-        path                = "health/"
+        path                = "/health/"
         port                = "traffic-port"
         protocol            = "HTTP"
         timeout             = 5

--- a/infra/alb.tf
+++ b/infra/alb.tf
@@ -50,7 +50,7 @@ module "alb" {
         healthy_threshold   = 2
         interval            = 30
         matcher             = "200"
-        path                = "/"
+        path                = "health/"
         port                = "traffic-port"
         protocol            = "HTTP"
         timeout             = 5

--- a/infra/alb.tf
+++ b/infra/alb.tf
@@ -6,22 +6,8 @@ module "alb" {
   vpc_id  = module.vpc.vpc_id
   subnets = module.vpc.public_subnets
 
-  security_group_ingress_rules = {
-    cloudflare_https = {
-      from_port   = 443
-      to_port     = 443
-      ip_protocol = "tcp"
-      description = "HTTPS from Cloudflare"
-      cidr_ipv4   = "0.0.0.0/0"
-    }
-  }
-  
-  security_group_egress_rules = {
-    all = {
-      ip_protocol = "-1"
-      cidr_ipv4   = "10.0.0.0/16"
-    }
-  }
+  security_groups = [module.alb_sg.security_group_id]
+    create_security_group = false
 
   listeners = {
     https = {

--- a/infra/alb.tf
+++ b/infra/alb.tf
@@ -40,7 +40,7 @@ module "alb" {
     app = {
       name_prefix      = "app-"
       protocol         = "HTTP"
-      port             = 80
+      port             = 8080
       target_type      = "ip"
       vpc_id           = module.vpc.vpc_id
       create_attachment = false

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -55,6 +55,10 @@ resource "aws_ecs_task_definition" "app" {
       {
         name  = "OSRM_HOST"
         value = "http://${aws_lb.osrm_internal.dns_name}:5000"
+      },
+      {
+        name  = "ALLOWED_HOSTS"
+        value = "*"
       }
     ]
     

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -19,7 +19,7 @@ resource "aws_ecs_task_definition" "app" {
     # Conditionally override the command to run migrations first
     command = var.run_migrations ? [
       "sh", "-c", 
-      "python manage.py makemigrations routes && python manage.py migrate && gunicorn trash_tracker.wsgi:application --bind 0.0.0.0:80"
+      "python manage.py makemigrations routes --noinput && python manage.py migrate && gunicorn trash_tracker.wsgi:application --bind 0.0.0.0:80"
     ] : null
     
     portMappings = [{

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -19,12 +19,12 @@ resource "aws_ecs_task_definition" "app" {
     # Conditionally override the command to run migrations first
     command = var.run_migrations ? [
       "sh", "-c", 
-      "python manage.py makemigrations routes --noinput && python manage.py migrate && gunicorn trash_tracker.wsgi:application --bind 0.0.0.0:80"
+      "python manage.py makemigrations routes --noinput && python manage.py migrate && gunicorn trash_tracker.wsgi:application --bind 0.0.0.0:8080"
     ] : null
     
     portMappings = [{
-      containerPort = 80
-      hostPort      = 80
+      containerPort = 8080
+      hostPort      = 8080
     }]
     
     environment = [
@@ -147,7 +147,7 @@ resource "aws_ecs_service" "app" {
   load_balancer {
     target_group_arn = module.alb.target_groups["app"].arn
     container_name   = "app-container"
-    container_port   = 80
+    container_port   = 8080
   }
   
   enable_execute_command = true

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -19,7 +19,7 @@ resource "aws_ecs_task_definition" "app" {
     # Conditionally override the command to run migrations first
     command = var.run_migrations ? [
       "sh", "-c", 
-      "python manage.py makemigrations routes --noinput && python manage.py migrate && gunicorn trash_tracker.wsgi:application --bind 0.0.0.0:8080"
+      "python manage.py makemigrations routes --noinput && python manage.py migrate && gunicorn config.wsgi:application --bind 0.0.0.0:8080"
     ] : null
     
     portMappings = [{

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -42,7 +42,7 @@ resource "aws_ecs_task_definition" "app" {
       },
       {
         name  = "DATABASE_NAME"
-        value = var.app_name
+        value = replace(var.app_name, "-", "_")
       },
       {
         name  = "DATABASE_USER"

--- a/infra/security.tf
+++ b/infra/security.tf
@@ -8,8 +8,8 @@ module "ecs_app_sg" {
 
   ingress_with_source_security_group_id = [
     {
-      from_port                = 80
-      to_port                  = 80
+      from_port                = 8080
+      to_port                  = 8080
       protocol                 = "tcp"
       description              = "HTTP from ALB"
       source_security_group_id = module.alb_sg.security_group_id

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -34,11 +34,11 @@ RUN useradd -m -u 1000 appuser && \
 USER appuser
 
 # Expose port
-EXPOSE 80
+EXPOSE 8080
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-    CMD python -c "import requests; requests.get('http://localhost:80/health/', timeout=5)" || exit 1
+    CMD python -c "import requests; requests.get('http://localhost:8080/health/', timeout=5)" || exit 1
 
 # Run gunicorn
-CMD ["gunicorn", "--bind", "0.0.0.0:80", "--workers", "3", "--timeout", "60", "--access-logfile", "-", "--error-logfile", "-", "config.wsgi:application"]
+CMD ["gunicorn", "--bind", "0.0.0.0:8080", "--workers", "3", "--timeout", "60", "--access-logfile", "-", "--error-logfile", "-", "config.wsgi:application"]

--- a/src/apps/routes/models.py
+++ b/src/apps/routes/models.py
@@ -13,7 +13,7 @@ class Address(models.Model):
 
 
 class Route(models.Model):
-    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    user = models.ForeignKey(User, on_delete=models.CASCADE, null=True)
     name = models.CharField(max_length=128)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -12,9 +12,6 @@ DEBUG = os.environ.get('DEBUG', 'False') == 'True'
 
 ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', 'localhost,127.0.0.1').split(',')
 
-# Add ALB health check path
-ALLOWED_HOSTS.append('.elb.amazonaws.com')  # For ALB health checks
-
 # Application definition
 INSTALLED_APPS = [
     'django.contrib.admin',

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -125,7 +125,6 @@ if not DEBUG:
 
 # Security settings for production
 if not DEBUG:
-    SECURE_SSL_REDIRECT = True
     CSRF_COOKIE_SECURE = True
     SECURE_BROWSER_XSS_FILTER = True
     SECURE_CONTENT_TYPE_NOSNIFF = True


### PR DESCRIPTION
Fix incorrect user reference in the app
Use the proper database name
Remove log check after migration
Change app port from 80 to 8080
Add manual deployment manipulation
Fix overriding command to reference correct WSGI file
Update health check to use “health”
Add leading slash to health-check path
Fix ALB security group to use the defined group instead of the managed one
Temporarily allow all hosts to debug health checks
Disable SSL redirection