### PR TITLE
Fix job dependencies, improve Terraform workflow with plan publishing and manual approval

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,11 +13,7 @@ on:
         required: false
         type: boolean
         default: true
-      deploy_solution:
-        description: 'Deploy the whole app without migration'
-        required: false
-        type: boolean
-        default: true
+
 env:
   AWS_REGION: eu-central-1
   ECR_REPOSITORY: trash-tracker/app
@@ -107,6 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - plan
+    if: always() && needs.plan.result == 'success'
     steps:
       - run: echo "Approved to Prod"
 
@@ -115,8 +112,7 @@ jobs:
       - build
       - manual-approval
     runs-on: ubuntu-latest
-    # Run when migrations are requested, regardless of build job status
-    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.manual-approval.result == 'success')
+    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped') && needs.manual-approval.result == 'success'
     
     steps:
     - name: Checkout code

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -99,7 +99,7 @@ jobs:
         fi
 
   manual-approval:
-    environment: 'Prod'
+    environment: 'production'
     runs-on: ubuntu-latest
     needs:
       - plan

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -100,7 +100,10 @@ jobs:
         terraform show -no-color tf.plan > tfplan.txt
         
     - name: Show Plan
-      run: cat ./infra/tfplan.txt
+      run: |
+        echo "++++++++++++++++++++++++"
+        cat ./infra/tfplan.txt
+        echo "++++++++++++++++++++++++"
 
     - name: Publish plan
       uses: actions/upload-artifact@v4
@@ -114,9 +117,7 @@ jobs:
     needs:
       - plan
     if: always() && needs.plan.result == 'success'
-    steps:
-
-      
+    steps:      
       - run: echo "Approved to Prod"
 
   deploy:
@@ -156,7 +157,7 @@ jobs:
         name: tfplan
         path: ./infra
 
-    - name: Deploy with Migrations
+    - name: Deploy according to tfplan
       working-directory: ./infra
       env:
         TF_VAR_app_container_image: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ needs.build.outputs.image-tag || 'latest' }}
@@ -167,7 +168,6 @@ jobs:
         TF_VAR_django_superuser_password: ${{ secrets.DJANGO_SUPERUSER_PASSWORD }}
         TF_VAR_request_rate_limit: ${{ vars.REQUEST_RATE_LIMIT }}
       run: terraform apply -auto-approve tf.plan
-
 
     - name: Get Outputs
       id: tf-outputs
@@ -188,5 +188,4 @@ jobs:
         echo "Container built: ${BUILD_RUN:-true}"
         echo "Migrations run: ${MIGRATIONS_RUN:-false}"
         echo "ALB DNS: $ALB_DNS"
-        echo "Your site: https://$DOMAIN"
         echo "=========================================="

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -93,10 +93,20 @@ jobs:
         TF_VAR_request_rate_limit: ${{ vars.REQUEST_RATE_LIMIT }}
       run: |
         if [ "${{ github.event.inputs.run_migrations }}" == "true" ]; then
-          terraform plan -var-file=migrate.tfvars
+          terraform plan -var-file=migrate.tfvars -out tf.plan
         else
-          terraform plan -var-file=prod.tfvars
+          terraform plan -var-file=prod.tfvars -out tf.plan
         fi
+        terraform show -no-color tf.plan > tfplan.txt
+        
+    - name: Show Plan
+      run: cat ./infra/tfplan.txt
+
+    - name: Publish plan
+      uses: actions/upload-artifact@v4
+      with:
+        name: tfplan
+        path: ./infra/tf.plan
 
   manual-approval:
     environment: 'production'
@@ -105,6 +115,8 @@ jobs:
       - plan
     if: always() && needs.plan.result == 'success'
     steps:
+
+      
       - run: echo "Approved to Prod"
 
   deploy:
@@ -137,7 +149,13 @@ jobs:
     - name: Terraform Init
       working-directory: ./infra
       run: terraform init -backend-config="backend.hcl"
-         
+
+    - name: Download tfplan
+      uses: actions/download-artifact@v4
+      with:
+        name: tfplan
+        path: ./infra
+
     - name: Deploy with Migrations
       working-directory: ./infra
       env:
@@ -148,12 +166,8 @@ jobs:
         TF_VAR_django_superuser_email: ${{ secrets.DJANGO_SUPERUSER_EMAIL }}
         TF_VAR_django_superuser_password: ${{ secrets.DJANGO_SUPERUSER_PASSWORD }}
         TF_VAR_request_rate_limit: ${{ vars.REQUEST_RATE_LIMIT }}
-      run: |
-        if [ "${{ github.event.inputs.run_migrations }}" == "true" ]; then
-          terraform apply -auto-approve -var-file=migrate.tfvars
-        else
-          terraform apply -auto-approve -var-file=prod.tfvars
-        fi
+      run: terraform apply -auto-approve tf.plan
+
 
     - name: Get Outputs
       id: tf-outputs


### PR DESCRIPTION
Remove deploy solution and fix dependencies between jobs
Fix environment name in manual-approval step
Add Terraform plan publishing functionality and use published plan in apply step
Show plan output before approval step
Adjust step names for better clarity
Add visual identification markers for plan output